### PR TITLE
Use CMake FetchContent to git clone CLIc

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,8 +20,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.2
@@ -38,8 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: recursive
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,6 +27,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_TEST_SKIP: *-macosx_arm64
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "CLIc"]
-	path = CLIc
-	url = https://github.com/clEsperanto/CLIc_prototype.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.20)
 # - package version is managed in file `version.py`
 project(pyClesperanto)
 
+# enforce release build type
 set(CMAKE_BUILD_TYPE Release)
 
 string(TOLOWER ${PROJECT_NAME} PY_PACKAGE_NAME)
@@ -25,19 +26,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON) # Require (at least) it
 # look for python in virtual env or conda first before checking the system.
 set(Python_FIND_VIRTUALENV "FIRST")
 find_package(Python3 COMPONENTS Interpreter Development.Embed Development.Module)
-
 if(Python3_Development.Module_FOUND)
     message(STATUS "Python Developement Module found")
 endif()
-
 if(Python3_Development.Embed_FOUND)
     message(STATUS "Python Developement Embed found")
 endif()
 
-message(STATUS "OpenCL_FOUND: ${OpenCL_FOUND}")
-message(STATUS "OpenCL_LIBRARY: ${OpenCL_LIBRARY}")
-message(STATUS "OpenCL_LIBRARIES: ${OpenCL_LIBRARIES}")
-
+# message(STATUS "OpenCL_FOUND: ${OpenCL_FOUND}")
+# message(STATUS "OpenCL_LIBRARY: ${OpenCL_LIBRARY}")
+# message(STATUS "OpenCL_LIBRARIES: ${OpenCL_LIBRARIES}")
 # CMake Warning:
 #   Manually-specified variables were not used by the project:
 #     PYTHON_INCLUDE_DIR
@@ -47,9 +45,25 @@ message(STATUS "OpenCL_LIBRARIES: ${OpenCL_LIBRARIES}")
 #     Python_INCLUDE_DIR
 #     Python_LIBRARY
 
-# Define CLIc Backend library
+## fetch CLIc using CMake FetchContent
+include(FetchContent)
+
+# ! how can we define the latest version, what happen if empty?
+# if(NOT CLIC_VERSION) # if not set, use latest
+#   set(CLIC_VERSION "0.6.2" CACHE PATH "CLIc version tag")
+# endif()
+
+# avoid build tests and examples for convenience
 option(BUILD_TESTING  OFF)
-add_subdirectory(CLIc)
+# fetch CLIc library
+FetchContent_Declare(
+  CLIc_lib 
+  GIT_REPOSITORY https://github.com/clEsperanto/CLIc_prototype.git
+  GIT_TAG ${CLIC_VERSION}
+)
+FetchContent_MakeAvailable(CLIc_lib)
+# Define CLIc Backend library
+# add_subdirectory(CLIc)
 
 if(SKBUILD)
   # Scikit-Build does not add your site-packages to the search path

--- a/pyclesperanto/__init__.py
+++ b/pyclesperanto/__init__.py
@@ -1,5 +1,6 @@
 # pyClEsperanto Import
 from ._version import VERSION as __version__
+from ._version import CLIC_VERSION as __clic_version__
 from ._memory_operations import (
     create,
     create_like,

--- a/pyclesperanto/_version.py
+++ b/pyclesperanto/_version.py
@@ -1,3 +1,9 @@
+# pyclesperanto version
 VERSION_CODE = (0, 6, 5)
 VERSION_STATUS = ""
 VERSION = ".".join(str(x) for x in VERSION_CODE) + VERSION_STATUS
+
+# clic version
+CLIC_VERSION_CODE = (0, 6, 2)
+CLIC_VERSION_STATUS = ""
+CLIC_VERSION = ".".join(str(x) for x in CLIC_VERSION_CODE) + CLIC_VERSION_STATUS

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,10 @@
-# # read the contents of your README file
-# from pathlib import Path
-
-# this_directory = Path(__file__).parent
-# long_description = (this_directory / "README.md").read_text()
-
-with open("README.md") as fp:
-    readme = fp.read()
-
-
 import sys, os
 
 sys.path.append(os.path.dirname(__file__))
 
+# Get the version from the version file and the package description from the README file
+with open("README.md") as fp:
+    readme = fp.read()
 
 ver_dic = {}
 version_file = open("pyclesperanto/_version.py")
@@ -22,11 +15,14 @@ finally:
 
 exec(compile(version_file_contents, "pyclesperanto/_version.py", "exec"), ver_dic)
 
+# build the package using skbuild
+
 from skbuild import setup
 
 setup(
     name="pyclesperanto",
     version=ver_dic["VERSION"],
+    cmake_args=["-DCLIC_VERSION:String=" + ver_dic["CLIC_VERSION"]],
     author="Stephane Rigaud",
     author_email="stephane.rigaud@pasteur.fr",
     license="BSD-3-Clause",


### PR DESCRIPTION
Now CLIc version to use is define in the _version.py of the pyclesperanto package
The version tag is then read by skbuild and passed to cmake which will git-clone the repository

PR to solve this issue:
- #35 