### PR TITLE
Enable dtype memory

### DIFF
--- a/pyclesperanto/_image_operators.py
+++ b/pyclesperanto/_image_operators.py
@@ -1,5 +1,14 @@
 import numpy as np
-from ._pyclesperanto import _Pull
+from ._pyclesperanto import (
+    _PullFloat,
+    _PullInt32,
+    _PullInt16,
+    _PullInt8,
+    _PullUint32,
+    _PullUint16,
+    _PullUint8,
+)
+from ._pyclesperanto import _cleDataType
 
 cl_buffer_datatype_dict = {
     bool: "bool",
@@ -40,7 +49,19 @@ class ImageOperators:
         else:
             raise ValueError("Axis " + axis + " not supported")
         if out is not None:
-            np.copyto(out, _Pull(result).astype(out.dtype))
+            if result.dtype == _cleDataType.uint8:
+                np.copyto(out, _PullUint8(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.uint16:
+                np.copyto(out, _PullUint16(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.uint32:
+                np.copyto(out, _PullUint32(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.int8:
+                np.copyto(out, _PullInt8(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.int16:
+                np.copyto(out, _PullInt16(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.int32:
+                np.copyto(out, _PullInt32(result).astype(out.dtype))
+            np.copyto(out, _PullFloat(result).astype(out.dtype))
         return result
 
     def min(self, axis: int = None, out=None):
@@ -61,7 +82,19 @@ class ImageOperators:
         else:
             raise ValueError("Axis " + axis + " not supported")
         if out is not None:
-            np.copyto(out, _Pull(result).astype(out.dtype))
+            if result.dtype == _cleDataType.uint8:
+                np.copyto(out, _PullUint8(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.uint16:
+                np.copyto(out, _PullUint16(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.uint32:
+                np.copyto(out, _PullUint32(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.int8:
+                np.copyto(out, _PullInt8(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.int16:
+                np.copyto(out, _PullInt16(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.int32:
+                np.copyto(out, _PullInt32(result).astype(out.dtype))
+            np.copyto(out, _PullFloat(result).astype(out.dtype))
         return result
 
     def sum(self, axis=None, out=None):
@@ -81,7 +114,19 @@ class ImageOperators:
         else:
             raise ValueError("Axis " + axis + " not supported")
         if out is not None:
-            np.copyto(out, _Pull(result).astype(out.dtype))
+            if result.dtype == _cleDataType.uint8:
+                np.copyto(out, _PullUint8(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.uint16:
+                np.copyto(out, _PullUint16(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.uint32:
+                np.copyto(out, _PullUint32(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.int8:
+                np.copyto(out, _PullInt8(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.int16:
+                np.copyto(out, _PullInt16(result).astype(out.dtype))
+            elif result.dtype == _cleDataType.int32:
+                np.copyto(out, _PullInt32(result).astype(out.dtype))
+            np.copyto(out, _PullFloat(result).astype(out.dtype))
         return result
 
     def __iadd__(x1, x2):

--- a/pyclesperanto/_memory_operations.py
+++ b/pyclesperanto/_memory_operations.py
@@ -1,10 +1,22 @@
 import numpy as np
-from ._pyclesperanto import _Create, _Push, _Pull
+from ._pyclesperanto import (
+    _Create,
+    _Push,
+    _PullFloat,
+    _PullInt32,
+    _PullInt16,
+    _PullInt8,
+    _PullUint32,
+    _PullUint16,
+    _PullUint8,
+)
 from ._device import Device, get_device
-from ._image import cleImage, Image, mType
+from ._image import cleImage, Image, mType, dType
 
 
-def create(shape: tuple, mtype: mType = None, device: Device = None) -> Image:
+def create(
+    shape: tuple, mtype: mType = None, dtype: dType = None, device: Device = None
+) -> Image:
     """create:
 
     Conventional method to create images on the GPU and return its handle
@@ -23,9 +35,11 @@ def create(shape: tuple, mtype: mType = None, device: Device = None) -> Image:
     """
     if mtype is None:
         mtype = mType.buffer
+    if dtype is None:
+        dtype = dType.float
     if device is None:
         device = get_device()
-    return cleImage(_Create(device, shape, mtype))
+    return cleImage(_Create(device, shape, dtype, mtype))
 
 
 def create_like(image: Image) -> Image:
@@ -45,7 +59,12 @@ def create_like(image: Image) -> Image:
         Handle of the empty GPU image
     """
     if isinstance(image, cleImage):
-        return create(shape=tuple(image.shape), mtype=image.mtype, device=image.device)
+        return create(
+            shape=tuple(image.shape),
+            dtype=image.dtype,
+            mtype=image.mtype,
+            device=image.device,
+        )
     else:
         return create(shape=tuple(image.shape), mtype=mType.buffer)
 
@@ -93,6 +112,18 @@ def pull(image: Image) -> Image:
         numpy compatible array
     """
     if isinstance(image, cleImage):
-        return _Pull(image)
+        if image.dtype == dType.uint8:
+            return _PullUint8(image)
+        elif image.dtype == dType.uint16:
+            return _PullUint16(image)
+        elif image.dtype == dType.uint32:
+            return _PullUint32(image)
+        elif image.dtype == dType.int8:
+            return _PullInt8(image)
+        elif image.dtype == dType.int16:
+            return _PullInt16(image)
+        elif image.dtype == dType.int32:
+            return _PullInt32(image)
+        return _PullFloat(image)
     else:
         return image


### PR DESCRIPTION
For now, only float type memory was possible in pyclesperanto.

The aim here is to make possible to create, push, and pull array of float, int32, int16 and int8 (and their unsigned equivalent).

- '`Create` can now take a dType
- `Push` is now templated on numpy type
- `Pull` is now type specific: `PullFloat`, `PullInt32`, etc.

Possible Issue:
- ImageOperator python class to mimic Numpy API request import of the wrapper function `_Pull` instead of the pythonised `pull` which now manage type return. Not a bloquing issue but code quality could be improve if we could rely on the pythonised `pull` instead.
- Any uses of non-valide CLIc type, should be cast as float32. Tests are needed.

---

How it look like for now :

```python
import pyclesperanto as cle
import numpy as np

buffer_short = cle.create( (5,5), cle.int16)          # <-- create an empty buffer space of short type
buffer_int = cle.push( np,ones((5,5), dtype=np.int32) )    # <-- push an array of int type
arr_int = cle.pull(buffer_int)                        # <-- pull a buffer of int into an array of int
```