### PR TITLE
CI ignore md/rst/txt when push to main

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,6 +3,11 @@ name: Tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+      - '**.txt'
+      - '**.yml'
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -7,7 +7,6 @@ on:
       - '**.md'
       - '**.rst'
       - '**.txt'
-      - '**.yml'
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,6 +4,11 @@ name: Build & Deploy
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '**.rst'
+      - '**.txt'
+      - '**.yml'
   pull_request:
     branches: [main]
   release:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,7 +8,6 @@ on:
       - '**.md'
       - '**.rst'
       - '**.txt'
-      - '**.yml'
   pull_request:
     branches: [main]
   release:


### PR DESCRIPTION
PR still check all
This is to avoid building wheels for a README update or a Documentation update