### PR TITLE
make 3.8 minimum python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 description = "GPU-accelerated image processing in python using OpenCL"
 name = "pyclesperanto"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 version = "0.11.1"
 
 [project.urls]
@@ -56,7 +56,6 @@ testpaths = ["tests"]
 
 [tool.cibuildwheel]
 build = [
-  "cp37-*",
   "cp38-*",
   "cp39-*",
   "cp310-*",
@@ -67,6 +66,7 @@ build = [
 skip = [
   "cp27-*",
   "cp36*",
+  "cp37*",
   "pp*",
   "*-win32",
   "*-musllinux*",


### PR DESCRIPTION
#220 requires minimal python version at `3.8`, hence it is time to drop `3.7` version.