### PR TITLE
add reshape function to Array class

### DIFF
--- a/pyclesperanto/_array.py
+++ b/pyclesperanto/_array.py
@@ -270,6 +270,11 @@ def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
     return NotImplemented
 
 
+def reshape(self, shape):
+    """Reshape the Array."""
+    return self.get().reshape(shape)
+
+
 # missing operators:
 # __array_interface__
 # __array_ufunc__
@@ -288,6 +293,7 @@ setattr(Array, "empty_like", classmethod(empty_like))
 setattr(Array, "zeros", classmethod(zeros))
 setattr(Array, "zeros_like", classmethod(zeros_like))
 setattr(Array, "to_device", classmethod(to_device))
+setattr(Array, "reshape", reshape)
 
 # Add operations and class methods from _operators module
 setattr(Array, "astype", _operators._astype)


### PR DESCRIPTION
Hi Stephane @StRigaud 

I had an error deep inside napari, that our Array class does not have a "reshape" function. This should fix the error.

Best,
Robert