### PR TITLE
Rename parameter "bool" to "wait_for_kernel_finish" to solve issue #262.

### DIFF
--- a/pyclesperanto/_core.py
+++ b/pyclesperanto/_core.py
@@ -126,7 +126,7 @@ def select_backend(backend: str = "opencl") -> str:
     return f"{BackendManager.get_backend()} selected."
 
 
-def wait_for_kernel_to_finish(flag: bool = True, device: Device = None):
+def wait_for_kernel_to_finish(wait: bool = True, device: Device = None):
     """Wait for kernel to finish
 
     Enforce the system to wait for the kernel to finish before continuing. Introducing a
@@ -135,15 +135,15 @@ def wait_for_kernel_to_finish(flag: bool = True, device: Device = None):
 
     Parameters
     ----------
-    flag : bool, default = True
+    wait : bool, default = True
         if True, wait for kernel to finish
     device : Device, default = None
         the device to set the flag. If None, set it to the current device
     """
     if device is None:
-        get_device().set_wait_to_finish(flag)
+        get_device().set_wait_to_finish(wait)
     else:
-        device.set_wait_to_finish(flag)
+        device.set_wait_to_finish(wait)
 
 
 def default_initialisation():

--- a/pyclesperanto/_interroperability.py
+++ b/pyclesperanto/_interroperability.py
@@ -78,12 +78,12 @@ def affine_transform(
     )
 
 
-def set_wait_for_kernel_finish(wait: bool =True):
+def set_wait_for_kernel_finish(wait_for_kernel_finish: bool =True):
     warnings.warn(
         "set_wait_for_kernel_finish : This method is deprecated. Consider using wait_for_kernel_to_finish() instead.",
         DeprecationWarning,
     )
-    wait_for_kernel_to_finish(wait)
+    wait_for_kernel_to_finish(wait_for_kernel_finish)
 
 
 def clip(a, a_min, a_max, out=None):

--- a/pyclesperanto/_interroperability.py
+++ b/pyclesperanto/_interroperability.py
@@ -83,7 +83,7 @@ def set_wait_for_kernel_finish(wait: bool =True):
         "set_wait_for_kernel_finish : This method is deprecated. Consider using wait_for_kernel_to_finish() instead.",
         DeprecationWarning,
     )
-    wait_for_kernel_to_finish(wait_for_kernel_finish)
+    wait_for_kernel_to_finish(wait)
 
 
 def clip(a, a_min, a_max, out=None):

--- a/pyclesperanto/_interroperability.py
+++ b/pyclesperanto/_interroperability.py
@@ -78,12 +78,12 @@ def affine_transform(
     )
 
 
-def set_wait_for_kernel_finish(wait_for_kernel_finish: bool =True):
+def set_wait_for_kernel_finish(wait: bool = True):
     warnings.warn(
         "set_wait_for_kernel_finish : This method is deprecated. Consider using wait_for_kernel_to_finish() instead.",
         DeprecationWarning,
     )
-    wait_for_kernel_to_finish(wait_for_kernel_finish)
+    wait_for_kernel_to_finish(wait)
 
 
 def clip(a, a_min, a_max, out=None):

--- a/pyclesperanto/_interroperability.py
+++ b/pyclesperanto/_interroperability.py
@@ -78,12 +78,12 @@ def affine_transform(
     )
 
 
-def set_wait_for_kernel_finish(bool=True):
+def set_wait_for_kernel_finish(wait_for_kernel_finish=True):
     warnings.warn(
         "set_wait_for_kernel_finish : This method is deprecated. Consider using wait_for_kernel_to_finish() instead.",
         DeprecationWarning,
     )
-    wait_for_kernel_to_finish(bool)
+    wait_for_kernel_to_finish(wait_for_kernel_finish)
 
 
 def clip(a, a_min, a_max, out=None):

--- a/pyclesperanto/_interroperability.py
+++ b/pyclesperanto/_interroperability.py
@@ -78,7 +78,7 @@ def affine_transform(
     )
 
 
-def set_wait_for_kernel_finish(wait_for_kernel_finish=True):
+def set_wait_for_kernel_finish(wait: bool =True):
     warnings.warn(
         "set_wait_for_kernel_finish : This method is deprecated. Consider using wait_for_kernel_to_finish() instead.",
         DeprecationWarning,


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.9.0, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

The changes made to address issue #262 involve updating the parameter name in the `set_wait_for_kernel_finish` function within the `pyclesperanto/_interroperability.py` file. Specifically, the parameter name was changed from `bool` to `wait_for_kernel_finish` to avoid using a type name as a parameter. This parameter is utilized to call the `wait_for_kernel_to_finish` function with the updated name, and the existing deprecation warning informs users to consider using `wait_for_kernel_to_finish()` directly. [View the modified file](https://github.com/clEsperanto/pyclesperanto/blob/git-bob-mod-8rItDeektA/pyclesperanto/_interroperability.py).

closes #262