### PR TITLE
Renamed `list` parameter to `label_image` in `exclude_labels`.

### DIFF
--- a/pyclesperanto/_tier3.py
+++ b/pyclesperanto/_tier3.py
@@ -102,7 +102,7 @@ def remove_labels(
 @plugin_function
 def exclude_labels(
     input_image: Image,
-    list: Image,
+    label_image: Image,
     output_image: Optional[Image] =None,
     device: Optional[Device] =None
 ) -> Image:
@@ -116,7 +116,7 @@ def exclude_labels(
     ----------
     input_image: Image 
         
-    list: Image 
+    label_image: Image 
         
     output_image: Optional[Image] (= None)
         
@@ -131,7 +131,7 @@ def exclude_labels(
     ----------
     [1] https://clij.github.io/clij2-docs/reference_excludeLabels
     """
-    return clic._exclude_labels(device, input_image, list, output_image)
+    return clic._exclude_labels(device, input_image, label_image, output_image)
 
 @plugin_function(categories=["label processing", "in assistant", "bia-bob-suggestion"])
 def remove_labels_on_edges(
@@ -591,7 +591,7 @@ def statistics_of_background_and_labelled_pixels(
         Label image to compute the statistics.
     intensity: Optional[Image] (= None)
         Intensity image.
-    device: Optional[Device] (= None)
+    device: Optional[Device] =None)
         Device to perform the operation on.
 
     Returns

--- a/tests/test_exclude_labels.py
+++ b/tests/test_exclude_labels.py
@@ -34,7 +34,7 @@ def test_exclude_labels_2d():
 
     flaglist = cle.push(np.asarray([[0, 0, 0, 1, 1, 0, 0, 1, 0]]).astype(np.uint32))
 
-    gpu_output = cle.exclude_labels(gpu_input, flaglist)
+    gpu_output = cle.exclude_labels(gpu_input, label_image=flaglist)
 
     a = cle.pull(gpu_output)
     b = cle.pull(gpu_reference)
@@ -82,7 +82,7 @@ def test_exclude_labels_3d():
 
     flaglist = cle.push(np.asarray([[0, 0, 0, 1, 1, 0, 0, 1, 0]]).astype(np.uint32))
 
-    gpu_output = cle.exclude_labels(gpu_input, flaglist)
+    gpu_output = cle.exclude_labels(gpu_input, label_image=flaglist)
 
     a = cle.pull(gpu_output)
     b = cle.pull(gpu_reference)


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.9.0, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

Renamed the parameter "list" to "label_image" in the `exclude_labels` function within `pyclesperanto/_tier3.py` to resolve issue #265, avoiding the use of a protected Python type name. This change was also reflected in the invocation of `exclude_labels` in the test file `tests/test_exclude_labels.py`. The test file can be viewed [here](https://github.com/clEsperanto/pyclesperanto/blob/git-bob-mod-l4Fi18izXc/tests/test_exclude_labels.py).

closes #265