### PR TITLE
Renamed the parameter "list" to "flag_list" in the exclude_labels function and updated tests.

### DIFF
--- a/pyclesperanto/_tier3.py
+++ b/pyclesperanto/_tier3.py
@@ -102,7 +102,7 @@ def remove_labels(
 @plugin_function
 def exclude_labels(
     input_image: Image,
-    list: Image,
+    flag_list: Image,
     output_image: Optional[Image] =None,
     device: Optional[Device] =None
 ) -> Image:
@@ -116,7 +116,7 @@ def exclude_labels(
     ----------
     input_image: Image 
         
-    list: Image 
+    flag_list: Image 
         
     output_image: Optional[Image] (= None)
         
@@ -131,7 +131,7 @@ def exclude_labels(
     ----------
     [1] https://clij.github.io/clij2-docs/reference_excludeLabels
     """
-    return clic._exclude_labels(device, input_image, list, output_image)
+    return clic._exclude_labels(device, input_image, flag_list, output_image)
 
 @plugin_function(categories=["label processing", "in assistant", "bia-bob-suggestion"])
 def remove_labels_on_edges(
@@ -429,7 +429,7 @@ def labelled_spots_to_pointlist(
         
     output_image: Optional[Image] (= None)
         
-    device: Optional[Device] (= None)
+    device: Optional[Device] =None
         Device to perform the operation on.
 
     Returns

--- a/tests/test_exclude_labels.py
+++ b/tests/test_exclude_labels.py
@@ -32,9 +32,9 @@ def test_exclude_labels_2d():
         ).astype(np.uint32)
     )
 
-    flaglist = cle.push(np.asarray([[0, 0, 0, 1, 1, 0, 0, 1, 0]]).astype(np.uint32))
+    flag_list = cle.push(np.asarray([[0, 0, 0, 1, 1, 0, 0, 1, 0]]).astype(np.uint32))
 
-    gpu_output = cle.exclude_labels(gpu_input, flaglist)
+    gpu_output = cle.exclude_labels(gpu_input, flag_list)
 
     a = cle.pull(gpu_output)
     b = cle.pull(gpu_reference)
@@ -80,9 +80,9 @@ def test_exclude_labels_3d():
         ).astype(np.uint32)
     )
 
-    flaglist = cle.push(np.asarray([[0, 0, 0, 1, 1, 0, 0, 1, 0]]).astype(np.uint32))
+    flag_list = cle.push(np.asarray([[0, 0, 0, 1, 1, 0, 0, 1, 0]]).astype(np.uint32))
 
-    gpu_output = cle.exclude_labels(gpu_input, flaglist)
+    gpu_output = cle.exclude_labels(gpu_input, flag_list)
 
     a = cle.pull(gpu_output)
     b = cle.pull(gpu_reference)


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.9.0, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

To resolve Issue #265, the parameter "list" in the `exclude_labels` function in `_tier3.py` was renamed to "flag_list" to avoid using a protected Python keyword. Corresponding changes were made to the function's documentation and the internal call to `clic._exclude_labels`. Additionally, the test cases in the newly added [tests/test_exclude_labels.py](https://github.com/clEsperanto/pyclesperanto/blob/git-bob-mod-emMJADHWXl/tests/test_exclude_labels.py) were updated to use "flag_list" instead of "flaglist", ensuring consistency and validating the refactor.

closes #265