### PR TITLE
Fix for incorrect function signature in `power()` from issue #271: updated parameters and order.

### DIFF
--- a/pyclesperanto/_interroperability.py
+++ b/pyclesperanto/_interroperability.py
@@ -128,22 +128,22 @@ def cbrt(x, out=None):
     return cubic_root(input_image=x, output_image=out, device=x.device)
 
 
-def power(x1, x2, out=None):
-    x1 = asarray(x1)
-    if out:
-        out = asarray(out)
+def power(input_image, output_image, exponent):
+    input_image = asarray(input_image)
+    if output_image:
+        output_image = asarray(output_image)
 
-    # test if x2 is a scalar
-    if np.isscalar(x2):
+    # test if exponent is a scalar
+    if np.isscalar(exponent):
         from ._tier1 import power
 
-        return power(input_image=x1, scalar=x2, output_image=out, device=x1.device)
+        return power(input_image=input_image, scalar=exponent, output_image=output_image, device=input_image.device)
     else:
         from ._tier1 import power_images
 
-        x2 = asarray(x2)
+        exponent = asarray(exponent)
         return power_images(
-            input_image0=x1, input_image1=x2, output_image=out, device=x1.device
+            input_image0=input_image, input_image1=exponent, output_image=output_image, device=input_image.device
         )
 
 


### PR DESCRIPTION
<sup>This message was generated by [git-bob](https://github.com/haesleinhuepf/git-bob) (version: 0.9.0, model: gpt-4o-2024-08-06), an experimental AI-based assistant. It can make mistakes and has [limitations](https://github.com/haesleinhuepf/git-bob?tab=readme-ov-file#limitations). Check its messages carefully.</sup>

To address issue #271, I modified the `pyclesperanto/_interoperability.py` file by updating the function signature of the `power()` function to `power(input_image, output_image, exponent)`. I also renamed the parameters: "x1" is now "input_image", "out" is now "output_image", and "x2" is now "exponent". These changes ensure that the function will now take parameters in the correct order, aligning with the intended design.

closes #271